### PR TITLE
add java version property for heroku

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,0 @@
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.username=mysqluser
-spring.datasource.password=mysqlpass
-spring.datasource.url=jdbc:mysql://localhost:3306/myDb?createDatabaseIfNotExist=true
-
-spring.jpa.database=mysql

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
Using https://stackoverflow.com/questions/53604111/heroku-cannot-deploy-java-11-spring-boot-app as a reference

to solve:        [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project SurveyMonkey: Fatal error compiling: invalid target release: 11 -> [Help 1]

from https://dashboard.heroku.com/apps/survey-monkey4806-24/activity/builds/58fa8a6a-1e45-4abf-9948-a31af450a247

